### PR TITLE
Change code examples on comparison slide

### DIFF
--- a/docs/aws/terraform/slides-tf.md
+++ b/docs/aws/terraform/slides-tf.md
@@ -372,12 +372,17 @@ Terraform vs. JSON
 <br><br><br>
 CloudFormation JSON:
 ```json
-{ "Fn::Join" : [ "delimiter", [ PilotServerName,3 ] ] }
+"Tags": [{
+            "Key": "Name",
+            "Value": { "Fn::Join:": ["-", [{ "Ref": "ServerName" }, "vm"]] }
+         }]
 ```
 
 Terraform:
 ```hcl
-name = "${var.PilotServerName}3"
+tags {
+  Name = "${var.ServerName}-vm"
+}
 ```
 
 Terraform code (HCL) is easy to learn and easy to read. It is also 50-70% more compact than an equivalent JSON configuration.

--- a/docs/azure/terraform/slides-tf.md
+++ b/docs/azure/terraform/slides-tf.md
@@ -378,12 +378,12 @@ Terraform vs. JSON
 <br><br><br>
 ARM JSON:
 ```json
-"name": "[concat(parameters('PilotServerName'), '3')]",
+"name": "[concat(parameters('PilotServerName'), '-vm')]",
 ```
 
 Terraform:
 ```hcl
-name = "${var.PilotServerName}3"
+name = "${var.PilotServerName}-vm"
 ```
 
 Terraform code (HCL) is easy to learn and easy to read. It is also 50-70% more compact than an equivalent JSON configuration.


### PR DESCRIPTION
Adjust CF & ARM code comparison slide

- switched CF & TF example to setting `tags`
  - fix CF expression and change ending to `-vm`
- switch ARM & TF example to use `-vm` suffix to match AWS example