### PR TITLE
Add Terraform Cloud on AWS to workshops page.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,10 @@
           <table>
             <tr>
               <td class="circleci"><a href="https://circleci.com/gh/hashicorp/field-workshops-terraform"><img src="https://circleci.com/gh/hashicorp/field-workshops-terraform.svg?style=svg"></a></td>
+              <td class="workshop"><a href="https://hashicorp.github.io/field-workshops-terraform/slides/aws/terraform-cloud/#1"><b>NEW:</b> Terraform Cloud on AWS</a> - A 3/4 day workshop for Terraform Cloud on AWS. Covers Enterprise features.</td>
+            </tr>
+            <tr>
+              <td class="circleci"><a href="https://circleci.com/gh/hashicorp/field-workshops-terraform"><img src="https://circleci.com/gh/hashicorp/field-workshops-terraform.svg?style=svg"></a></td>
               <td class="workshop"><a href="https://hashicorp.github.io/field-workshops-terraform/slides/azure/terraform-oss/#1">Intro to Terraform OSS on Azure</a> - A half day workshop for Terraform on Azure.</td>
             </tr>
             <tr>


### PR DESCRIPTION
Instruqt have load tested the track with 50 simultaneous instances, it ran no problem.