### PR TITLE
add Advanced Nomad workshop, fix Sentinel slides link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,12 +49,13 @@
             <tr>
               <td class="circleci"><a href="https://circleci.com/gh/hashicorp/field-workshops-nomad"><img src="https://circleci.com/gh/hashicorp/field-workshops-nomad.svg?style=svg"></a></td>
               <td class="icon"><img class="icon" src="./nomad_icon.png"></td>
-              <td class="content"><a href="https://hashicorp.github.io/field-workshops-nomad/slides/multi-cloud/nomad-oss/#1">Intro to Nomad</a> - A 3/4 day workshop on Nomad. Cloud agnostic.</td>
+              <td class="content"><a href="https://hashicorp.github.io/field-workshops-nomad/slides/multi-cloud/nomad-oss/#1">Intro to Nomad</a> - A 1/2 day workshop on Nomad. Cloud agnostic.<a href="https://hashicorp.github.io/field-workshops-nomad/slides/multi-cloud/advanced-nomad/#1">Advanced Nomad</a> - A 1/2 day workshop on Nomad. Cloud agnostic.
+              </td>
             </tr>
             <tr>
               <td class="circleci"><a href="https://circleci.com/gh/hashicorp/field-workshops-terraform"><img src="https://circleci.com/gh/hashicorp/field-workshops-terraform.svg?style=svg&circle-token=3ae20ad84b4220d3e1002b58b1aeae863a9c71ec"></a></td>
               <td class="icon"><img class="icon" src="./terraform_icon.png"></td>
-              <td class="content"><a href="https://drive.google.com/file/d/1iFff7wYhiRLQyWiRXDSN6HJ5CGVGy5xI/view">Sentinel in Terraform</a> - A half day workshop on Sentinel in Terraform Cloud and Terraform Enterprise. Cloud agnostic.</td>
+              <td class="content"><a href="https://github.com/hashicorp/field-workshops-terraform/raw/master/docs/slides/multi-cloud/sentinel-for-terraform/Sentinel-for-Terraform-v2.pptx">Sentinel in Terraform</a> - A half day workshop on Sentinel in Terraform Cloud and Terraform Enterprise. Cloud agnostic.</td>
             </tr>
           </table>
           <br>


### PR DESCRIPTION
I added the new Advanced Nomad workshop, set it and the Intro to Nomad workshop to 1/2 day (after shifting Nomad Security and ACLs lab to the Advanced workshop).

I also corrected link for Sentinel for Terraform v2 slides to point to GitHub instead of Google Drive.